### PR TITLE
Update view logic with support for helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ define('WPS_INCLUDES_DIR', $template_dir . '/includes/wps');
 define('WPS_MODELS_DIR', $template_dir . '/app/models');
 define('WPS_VIEWS_DIR', $template_dir . '/app/views');
 define('WPS_CONTROLLERS_DIR', $template_dir . '/app/controllers');
+define('WPS_HELPERS_DIR', $template_dir . '/app/helpers');
 
 // Defines load priorities for use with actions and filters
 define('LOAD_ON_INIT', 1);
@@ -196,3 +197,55 @@ type.
 
 Note that `CMB2_PREFIX` is a constant defined within your `constants.php` file
 and should be added before each custom metabox field id.
+
+### Adding Views
+
+The views folder is designed to house components, reusable sections of code
+along with template specific blocks to help break down the primary WordPress
+template pages.
+
+A view partial can be rendered into a page template by creating an instance of
+the view class (you should only have one instance per page) and then calling the
+render method as shown below:
+
+```php
+$homepage_view = new WPS\View(get_the_ID());
+$homepage_view->render('homepage/hero-slider');
+```
+
+The above code will look within the views folder for a subfolder of `homepage`
+containing a file named `hero-slider-tpl.php`. You can pass the filename
+suffix and file extension (`-tpl.php`), however, these are not required by
+default.
+
+The View's class contains a series of methods to help manage simple interactions
+with CMB2, the custom metabox library used in this library.
+
+TODO: Add reference list of View methods
+
+#### View Helpers
+
+In order to reduce the 'mess' that is often found in WordPress templates, helper
+methods can be created and utilised via any instance of the `WPS\View` class.
+
+Helper methods should only be used for view based functionality, i.e.
+interacting with items displayed within a template or subsequent partial, such
+as manipulating the text output for an excerpt. They should not be used for
+query logic or anything else outside the scope of a view.
+
+To add a new helper class, create a new php file within the `WPS_HELPERS_DIR`
+directory, I'd recommend setting the helper constant to `app/helpers`.
+
+Below is an example helper file which can be used as a guide:
+
+```php
+class HomepageHeroHelper {
+  public function format_hero_subtitle($text) {
+    return str_replace(' ', '-', $text);
+  }
+}
+```
+
+This method can then be called by any view or within any partial/component that
+has been included via the `render` method via
+`$this->helper->format_hero_subtitle($subtitle)`

--- a/class.view-helper.php
+++ b/class.view-helper.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WPS;
+
+class ViewHelper {
+  private $_helper_classes;
+
+  public function __construct($helper_classes) {
+    $this->_helper_classes = $helper_classes;
+  }
+
+  public function __call($method_name, $method_args) {
+    foreach($this->_helper_classes as $helper_class => $class_obj) {
+      if(method_exists($class_obj, $method_name)) {
+        return call_user_func_array([$class_obj, $method_name], $method_args);
+      }
+    }
+
+    trigger_error("No helper class method found for: $method_name");
+  }
+}

--- a/class.view-helpers-loader.php
+++ b/class.view-helpers-loader.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WPS;
+
+class ViewHelpersLoader extends \WPS {
+  private static $_helper_classes = [];
+
+  public static function init() {
+    if(file_exists(WPS_HELPERS_DIR)) {
+      self::load_files_within(
+        WPS_HELPERS_DIR,
+        'WPS\ViewHelpersRecursiveFilterIterator',
+        'WPS\ViewHelpersLoader::helpers_loader_callback'
+      );
+    }
+
+    return self::$_helper_classes;
+  }
+
+  public static function helpers_loader_callback($filename) {
+    $filter_filename = str_replace(['class.', '.php'], '', $filename);
+    $class_name = str_replace('-', '', implode(
+      '-',
+      array_map('ucfirst', explode('-', $filter_filename))
+    ));
+
+    if(class_exists($class_name)) {
+      self::$_helper_classes[$class_name] = new $class_name;
+    }
+  }
+}
+
+class ViewHelpersRecursiveFilterIterator extends FilterIterator {
+  protected $file_prefixes = ['class.'];
+}

--- a/class.view.php
+++ b/class.view.php
@@ -7,7 +7,8 @@ class View {
          $field_prefix,
          $img_width,
          $img_height,
-         $render_args;
+         $render_args,
+         $helper;
 
   public $cmb_prefix = CMB2_PREFIX;
 
@@ -20,6 +21,7 @@ class View {
 
   public function __construct($post_id) {
     $this->post_id = $post_id;
+    $this->helper = new ViewHelper(ViewHelpersLoader::init());
   }
 
   public function set_image_size($width, $height) {


### PR DESCRIPTION
- Adds `ViewHelpersLoader` & `ViewHelper` classes to handle the
  pre-loading of all available view helpers, found with the directory
  defined by the `WPS_HELPERS_DIR` constant.
- Helper methods can be used within any `View` class instance via
  `$this->helper`, calling the associated helper method at the end
  `$this->helper->format_title($title)`.
- Updates README with information about views and helpers
