### PR TITLE
Add query logic to models

### DIFF
--- a/class.model.php
+++ b/class.model.php
@@ -3,19 +3,23 @@
 namespace WPS;
 
 class Model {
-  public $post_type;
-  public $default_cpt_args = [
-    'public' => false,
-    'show_ui' => true,
-    'show_in_nav_menus' => true,
-    'capability_type' => 'post',
-    'supports' => [
-      'title',
-      'editor',
-      'thumbnail',
-      'page-attributes'
-    ]
-  ];
+  public $post_type,
+         $default_cpt_args = [
+           'public' => false,
+           'show_ui' => true,
+           'show_in_nav_menus' => true,
+           'capability_type' => 'post',
+           'supports' => [
+             'title',
+             'editor',
+             'thumbnail',
+             'page-attributes'
+           ]
+         ],
+         $default_query_args = [
+           'paged' => 1,
+           'post_status' => 'publish'
+         ];
 
   public function __construct($post_type, array $cpt_args = []) {
     $this->post_type = $post_type;
@@ -26,7 +30,30 @@ class Model {
     );
   }
 
+  public function query(array $query_args = null) {
+    $this->default_query_args['post_type'] = $this->post_type;
+    $this->default_query_args['posts_per_page'] = get_option('posts_per_page');
+
+    $args = array_merge(
+      $this->default_query_args,
+      (!empty($query_args) ? $this->set_paged_value($query_args) : [])
+    );
+
+    return new \WP_Query($args);
+  }
+
   private function register_custom_post_type($cpt, $cpt_args) {
     register_post_type($cpt, $cpt_args);
+  }
+
+  private function set_paged_value(array $query_args) {
+    $default_paged = !empty($query_args['paged']) ?
+      $query_args['paged'] :
+      $this->default_query_args['paged'];
+
+    $paged_query_var = get_query_var('paged');
+    $query_args['paged'] = $paged_query_var ? $paged_query_var : $default_paged;
+
+    return $query_args;
   }
 }

--- a/class.view.php
+++ b/class.view.php
@@ -8,19 +8,20 @@ class View {
          $img_width,
          $img_height,
          $render_args,
-         $helper;
+         $helper,
+         $cmb_prefix = CMB2_PREFIX,
+         $field_defaults = [
+           'multi'       => false,
+           'multi_val'   => null,
+           'is_single'   => true,
+           'placeholder' => false
+         ];
 
-  public $cmb_prefix = CMB2_PREFIX;
-
-  public $field_defaults = [
-    'multi'       => false,
-    'multi_val'   => null,
-    'is_single'   => true,
-    'placeholder' => false
-  ];
+  private $_initialised_post_id;
 
   public function __construct($post_id) {
     $this->post_id = $post_id;
+    $this->_initialised_post_id = $post_id;
     $this->helper = new ViewHelper(ViewHelpersLoader::init());
   }
 
@@ -98,6 +99,14 @@ class View {
 
   public function format_content($content) {
     return apply_filters('the_content', $content);
+  }
+
+  public function set_new_post_id(int $new_post_id) {
+    $this->post_id = $new_post_id;
+  }
+
+  public function restore_previous_post_id() {
+    $this->post_id = $this->_initialised_post_id;
   }
 
   protected function get_cmb2_field($field, $is_single = true) {


### PR DESCRIPTION
- Allows for model classes to generate a `WP_Query` instance by calling
  `->query` on themselves
- Adds check to prevent recreating of CPT models when called to perform
  a query
