### PR TITLE
Reset post id to initialised id after each render

### DIFF
--- a/class.view.php
+++ b/class.view.php
@@ -86,6 +86,8 @@ class View {
 
     if(file_exists($render_path)) {
       include($render_path);
+
+      $this->restore_previous_post_id();
     } else {
       trigger_error("No template found for: $template_file ($template_name)");
     }


### PR DESCRIPTION
- Removes the need to manually call `$this->restore_previous_post_id()`
  after (or at the end of) each rendered partial file
