### PR TITLE
Amend way in which WPS is loaded and how it's autoloaders run

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,25 +44,21 @@ within your existing code/framework.
 # Functions file for loading of core files via autoloading methods
 
 require_once(get_template_directory() . '/includes/constants.php');
+require_once(WPS_INCLUDES_DIR . '/class.wps.php');
 
 class MyTheme {
-  public function __construct() {
-    $this->init();
-    $this->include_wp_functions();
+  public static function init() {
+    WPS::init();
 
-    WPS::load_wps_core();
+    self::include_wp_functions();
   }
 
-  private function init() {
-    require_once(WPS_INCLUDES_DIR . '/class.autoloaders.php');
-
-    new WPS\Autoloaders();
+  private static function include_wp_functions() {
+    // Theme functions, support and includes etc
   }
-
-  private function include_wp_functions() {}
 }
 
-new MyTheme();
+MyTheme::init();
 ```
 
 Inside the folder you have included this repo as a submodule (suggested folder

--- a/class.autoloaders.php
+++ b/class.autoloaders.php
@@ -3,29 +3,29 @@
 namespace WPS;
 
 class Autoloaders {
-  public function __construct() {
-    spl_autoload_register([$this, 'autoload_lib_classes']);
-    spl_autoload_register([$this, 'autoload_classes']);
+  public static function init() {
+    spl_autoload_register([__CLASS__, 'autoload_lib_classes']);
+    spl_autoload_register([__CLASS__, 'autoload_classes']);
 
     if(function_exists('__autoload')) {
-      spl_autoload_register([$this, '__autoload']);
+      spl_autoload_register([__CLASS__, '__autoload']);
     }
   }
 
-  public function autoload_classes($name) {
-    $class_name = $this->format_class_filename($name);
-    $class_path = $this->class_file_path($class_name);
+  public static function autoload_classes($name) {
+    $class_name = self::format_class_filename($name);
+    $class_path = self::class_file_path($class_name);
 
     if(file_exists($class_path)) require_once $class_path;
   }
 
-  public function autoload_lib_classes($name) {
-    $lib_class_name = $this->class_file_path($name);
+  public static function autoload_lib_classes($name) {
+    $lib_class_name = self::class_file_path($name);
 
     if(file_exists($lib_class_name)) require_once($lib_class_name);
   }
 
-  protected function format_class_filename($filename) {
+  protected static function format_class_filename($filename) {
     return strtolower(
       implode(
         '-',
@@ -34,19 +34,19 @@ class Autoloaders {
     );
   }
 
-  protected function class_file_path($filename, $dir = __DIR__) {
+  protected static function class_file_path($filename, $dir = __DIR__) {
     if(strpos($filename, '\\') !== false) {
-      return $this->load_namespaced_class($filename);
+      return self::load_namespaced_class($filename);
     }
 
     return $dir . '/class.' . strtolower($filename) . '.php';
   }
 
-  private function load_namespaced_class($file_path) {
+  private static function load_namespaced_class($file_path) {
     $file_path_parts = explode('/', str_replace('\\', '/', $file_path));
     $file_path_keys = array_keys($file_path_parts);
     $class_filename_key = end($file_path_keys);
-    $class_filename = $this->format_class_filename(
+    $class_filename = self::format_class_filename(
       $file_path_parts[$class_filename_key]
     );
     $file_path_parts[$class_filename_key] = 'class.' . $class_filename  . '.php';

--- a/class.wps.php
+++ b/class.wps.php
@@ -1,9 +1,16 @@
 <?php
 
+require_once(WPS_INCLUDES_DIR . '/class.autoloaders.php');
+
 class WPS {
-  final public static function load_wps_core() {
-    new WPS\Controllers();
+  public static function init() {
+    self::load_wps_core();
+  }
+
+  private static function load_wps_core() {
+    WPS\Autoloaders::init();
     WPS\ModelsLoader::init();
+    new WPS\Controllers();
   }
 
   protected static function load_files_within($dir, $filter_iterator, $callback = null) {


### PR DESCRIPTION
- Make autoloader methods static and calls from `WPS` core class
  rather than require a user to include the autoloaders manually. Now
  just the main `class.wps.php` file is required and then a simple
  `WPS::init();` is all that is required to load it
