### PR TITLE
Allow for null post id on initialisation of WPS\View class

### DIFF
--- a/class.view.php
+++ b/class.view.php
@@ -19,7 +19,7 @@ class View {
 
   private $_initialised_post_id;
 
-  public function __construct($post_id) {
+  public function __construct($post_id = null) {
     $this->post_id = $post_id;
     $this->_initialised_post_id = $post_id;
     $this->helper = new ViewHelper(ViewHelpersLoader::init());


### PR DESCRIPTION
- Sets default `$post_id` in `WPS\View` class construct to `null`,
  which allows for components/view partials that do not sit within
  a WP loop or belong to a collection or individual post to be
  rendered, i.e. navigation menu partial from the `header.php` file
