### PR TITLE
Add initial controller logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,40 @@ class HomepageHeroHelper {
 This method can then be called by any view or within any partial/component that
 has been included via the `render` method via
 `$this->helper->format_hero_subtitle($subtitle)`
+
+### Adding Controllers
+
+The `controller` folder is where your controller logic lives, separated into a
+separate class per post type.
+
+A controller class contains the logic and variables passed into a page template.
+This could be a query object for a collection of items, i.e. a set of posts for
+a listing view. Below is an example of a controller that can be used with a
+custom post type archive listing view:
+
+```php
+class PortfolioController extends WPS\Controller {
+  public function __construct($post_type = null, $template_fallback) {
+    parent::__construct($post_type, $template_fallback);
+  }
+
+  public function index($template) {
+    $portfolio_items = [78 => 'test 1', 87 => 'test 2'];
+
+    include $template;
+  }
+}
+```
+
+In the example above, the post type is automatically set to the current post
+type detected by WordPress (via `get_query_var` method) which in turn is what
+links up the use of the controllers.
+
+Here the post type is `portfolio`, so the `PortfolioController` class is loaded
+and because the template being requested is the `archive` template
+(`archive-portfolio.php`), the `index` method is called. The `$portfolio_items`
+variable is then exposed to the template and available within the view.
+
+Note: Currently only `archive-{$post_type}.php` files are supported and routed
+through these controllers. This will be updated in future PR's in order to fully
+support standard templates and individual posts/pages prior to `v1.0.0`

--- a/class.controller.php
+++ b/class.controller.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WPS;
+
+class Controller {
+  public $post_type;
+
+  public function __construct($post_type, $template_fallback) {
+    $this->post_type = $post_type;
+
+    if(!is_post_type_archive()) return $template_fallback;
+
+  	$archive_template = WPS_VIEWS_DIR . "/{$post_type}/archive-{$post_type}.php";
+
+    if(file_exists($archive_template)) {
+      $this->index($archive_template);
+
+      return false;
+    }
+
+    return $template_fallback;
+  }
+
+  public function index($template) {
+    include $template;
+  }
+
+  public function single($template) {
+    include $template;
+  }
+}

--- a/class.controllers-loader.php
+++ b/class.controllers-loader.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WPS;
+
+class ControllersLoader {
+  public static function init() {
+    add_filter('template_include', [__CLASS__, 'load_cpt_archive_controller']);
+  }
+
+  public static function load_cpt_archive_controller($template) {
+    $controller = self::load_controller(get_query_var('post_type'), $template);
+
+    if(!empty($controller)) return $controller;
+
+    return $template;
+  }
+
+  private static function load_controller($post_type, $template_fallback) {
+    $load_path = WPS_CONTROLLERS_DIR . "/controller.{$post_type}.php";
+
+    if(file_exists($load_path)) {
+      require_once $load_path;
+
+      $controller_name = ucwords($post_type) . 'Controller';
+      new $controller_name($post_type, $template_fallback);
+    }
+
+    return false;
+  }
+}

--- a/class.wps.php
+++ b/class.wps.php
@@ -10,7 +10,7 @@ class WPS {
   private static function load_wps_core() {
     WPS\Autoloaders::init();
     WPS\ModelsLoader::init();
-    new WPS\Controllers();
+    WPS\ControllersLoader::init();
   }
 
   protected static function load_files_within($dir, $filter_iterator, $callback = null) {


### PR DESCRIPTION
- Adds controller logic loader via the `template_include` WordPress filter
  to take the current post type and then load the controller file if found.
- The controller is then responsible for rendering the correct page template,
  currently, only custom post type archives have been implemented but single
  post items, post and page types will be added in the next PR
