### PR TITLE
Fix bug whereby fallback template whast still being called and rendered

### DIFF
--- a/class.controller.php
+++ b/class.controller.php
@@ -8,17 +8,21 @@ class Controller {
   public function __construct($post_type, $template_fallback) {
     $this->post_type = $post_type;
 
-    if(!is_post_type_archive()) return $template_fallback;
+    if(!is_post_type_archive()) {
+      $this->fallback_template($template_fallback);
+
+      return;
+    }
 
   	$archive_template = WPS_VIEWS_DIR . "/{$post_type}/archive-{$post_type}.php";
 
     if(file_exists($archive_template)) {
       $this->index($archive_template);
 
-      return false;
+      return;
     }
 
-    return $template_fallback;
+    $this->fallback_template($template_fallback);
   }
 
   public function index($template) {
@@ -26,6 +30,10 @@ class Controller {
   }
 
   public function single($template) {
+    include $template;
+  }
+
+  public function fallback_template($template) {
     include $template;
   }
 }

--- a/class.controllers-loader.php
+++ b/class.controllers-loader.php
@@ -10,9 +10,7 @@ class ControllersLoader {
   public static function load_cpt_archive_controller($template) {
     $controller = self::load_controller(get_query_var('post_type'), $template);
 
-    if(!empty($controller)) return $controller;
-
-    return $template;
+    if(empty($controller)) return $template;
   }
 
   private static function load_controller($post_type, $template_fallback) {
@@ -23,6 +21,8 @@ class ControllersLoader {
 
       $controller_name = ucwords($post_type) . 'Controller';
       new $controller_name($post_type, $template_fallback);
+
+      return true;
     }
 
     return false;


### PR DESCRIPTION
- In the `ControllerLoader` class, the exit/return statements where
  always being returned as there was no return status for a valid
  controller when loaded alongside a valid template.
- This commit sets the fallback template to run only when `false` is
  returned by the `load_controller` method and also adds similar return
  cycle checks to the base controller class to enforce the correct
  template is only loaded once before closing off the template include
  and redirect cycle during page load
