### PR TITLE
Expand controller logic for other post types and template routes

### DIFF
--- a/class.controller.php
+++ b/class.controller.php
@@ -3,18 +3,45 @@
 namespace WPS;
 
 class Controller {
-  public $post_type;
+  public $post_type,
+         $current_query;
 
-  public function __construct($post_type, $template_fallback) {
+  public function __construct($post_type, $current_query = null, $template) {
     $this->post_type = $post_type;
+    $this->current_query = $this->set_current_query($current_query);
+    $this->render_post_route_template($template);
+  }
 
+  private function render_post_route_template($template) {
     if(!is_post_type_archive()) {
-      $this->fallback_template($template_fallback);
+      $this->render_single_template($template);
 
       return;
     }
 
-  	$archive_template = WPS_VIEWS_DIR . "/{$post_type}/archive-{$post_type}.php";
+  	$this->render_archive_template($template);
+  }
+
+  private function render_single_template($template) {
+    if(is_single()) {
+      $single_template = WPS_VIEWS_DIR .
+        "/{$this->post_type}/single-{$this->post_type}.php";
+
+      if(file_exists($single_template)) {
+        $this->single($single_template);
+
+        return;
+      }
+    }
+
+    $this->single($template);
+
+    return;
+  }
+
+  private function render_archive_template($template) {
+    $archive_template = WPS_VIEWS_DIR .
+      "/{$this->post_type}/archive-{$this->post_type}.php";
 
     if(file_exists($archive_template)) {
       $this->index($archive_template);
@@ -22,18 +49,26 @@ class Controller {
       return;
     }
 
-    $this->fallback_template($template_fallback);
+    $this->single($template);
   }
 
   public function index($template) {
-    include $template;
+    $this->render_template($template);
   }
 
   public function single($template) {
+    $this->render_template($template);
+  }
+
+  private function render_template($template) {
     include $template;
   }
 
-  public function fallback_template($template) {
-    include $template;
+  private function set_current_query($query) {
+    if(!empty($current_query)) return $query;
+
+    global $wp_query;
+
+    return $wp_query;
   }
 }

--- a/class.controllers-loader.php
+++ b/class.controllers-loader.php
@@ -2,29 +2,124 @@
 
 namespace WPS;
 
-class ControllersLoader {
+class ControllersLoader extends \WPS {
+  private static $current_query,
+                 $template,
+                 $_wp_page_templates,
+                 $_wp_cache_expiry = 1800;
+
   public static function init() {
+    global $wp_query;
+
+    self::$current_query = $wp_query;
+
+    add_filter('theme_page_templates', [__CLASS__, 'filter_wps_view_templates'], LOAD_AFTER_WP, 2);
     add_filter('template_include', [__CLASS__, 'load_cpt_archive_controller']);
   }
 
   public static function load_cpt_archive_controller($template) {
-    $controller = self::load_controller(get_query_var('post_type'), $template);
+    self::$template = $template;
+    $controller = self::load_controller();
 
     if(empty($controller)) return $template;
   }
 
-  private static function load_controller($post_type, $template_fallback) {
+  public static function filter_wps_view_templates($page_templates, $theme) {
+    $current_page_templates = wp_cache_get(
+      "page_templates-{$theme->cache_hash}",
+      'themes'
+    );
+
+    $page_templates = is_array($current_page_templates) ?
+      $current_page_templates :
+      [];
+
+    $_wps_template_files = self::load_files_within(
+      WPS_VIEWS_DIR,
+      'WPS\TemplatesRecursiveFilterIterator',
+      'WPS\ControllersLoader::build_wp_page_templates_array',
+      false
+    );
+
+    foreach(self::$_wp_page_templates as $file => $full_path) {
+      if(!preg_match('|Template Name:(.*)$|mi', file_get_contents($full_path), $header)) {
+        continue;
+      }
+
+      $page_templates[$file] = _cleanup_header_comment($header[1]);
+    }
+
+    wp_cache_add(
+      "page_templates-{$theme->cache_hash}",
+      $page_templates,
+      'themes',
+      self::$_wp_cache_expiry
+    );
+
+    return $page_templates;
+  }
+
+  public static function build_wp_page_templates_array($file) {
+    $local_file_path = str_replace(
+      get_template_directory(),
+      '',
+      $file->getPathname()
+    );
+
+    self::$_wp_page_templates[$local_file_path] = $file->getPathname();
+  }
+
+  private static function get_current_post_type() {
+    $post_type = !empty(self::$current_query->query['post_type']) ?
+      self::$current_query->query['post_type'] :
+      self::$current_query->queried_object->post_type;
+
+    if($post_type !== 'page') return $post_type;
+
+    return self::get_page_template_controller_name($post_type);
+  }
+
+  private static function get_page_template_controller_name($post_type) {
+    $page_template = get_post_meta(
+      self::$current_query->queried_object->ID,
+      '_wp_page_template',
+      true
+    );
+
+    if(empty($page_template)) return $post_type;
+
+    $page_name = str_replace(['page-', '.php'], '', $page_template);
+
+    self::$template = WPS_VIEWS_DIR . "/$post_type/$page_template";
+
+    return "$page_name-$post_type";
+  }
+
+  private static function load_controller() {
+    $post_type = self::get_current_post_type();
     $load_path = WPS_CONTROLLERS_DIR . "/controller.{$post_type}.php";
 
     if(file_exists($load_path)) {
       require_once $load_path;
 
-      $controller_name = ucwords($post_type) . 'Controller';
-      new $controller_name($post_type, $template_fallback);
+      $controller_name = self::get_controller_name($post_type);
+      new $controller_name($post_type, self::$current_query, self::$template);
 
       return true;
     }
 
     return false;
   }
+
+  private static function get_controller_name($post_type) {
+    return str_replace(
+      '-',
+      '',
+      implode('-', array_map('ucfirst', explode('-', $post_type)))
+    ) . 'Controller';
+  }
+}
+
+class TemplatesRecursiveFilterIterator extends FilterIterator {
+  protected $file_prefixes = ['page', 'single'];
 }

--- a/class.models-loader.php
+++ b/class.models-loader.php
@@ -21,11 +21,11 @@ class ModelsLoader extends \WPS {
     }
   }
 
-  public static function loader_callback($filename) {
+  public static function loader_callback($file) {
     $filter_filename = str_replace(
       ['cmb2.', 'model.', '.php'],
       '',
-      $filename
+      $file->getFilename()
     );
     $class_name = implode(
       '-',

--- a/class.view-helpers-loader.php
+++ b/class.view-helpers-loader.php
@@ -17,8 +17,8 @@ class ViewHelpersLoader extends \WPS {
     return self::$_helper_classes;
   }
 
-  public static function helpers_loader_callback($filename) {
-    $filter_filename = str_replace(['class.', '.php'], '', $filename);
+  public static function helpers_loader_callback($file) {
+    $filter_filename = str_replace(['class.', '.php'], '', $file->getFilename());
     $class_name = str_replace('-', '', implode(
       '-',
       array_map('ucfirst', explode('-', $filter_filename))

--- a/class.wps.php
+++ b/class.wps.php
@@ -13,7 +13,7 @@ class WPS {
     WPS\ControllersLoader::init();
   }
 
-  protected static function load_files_within($dir, $filter_iterator, $callback = null) {
+  public static function load_files_within($dir, $filter_iterator, $callback = null, $load_file = true) {
     $dir_files = new RecursiveDirectoryIterator(
       $dir,
       RecursiveDirectoryIterator::SKIP_DOTS
@@ -28,9 +28,9 @@ class WPS {
 
     foreach($files_iterator as $file) {
       if($file->isFile()) {
-        require_once($file->getPathname());
+        if($load_file) require_once($file->getPathname());
 
-        if(!empty($callback)) $callback($file->getFilename());
+        if(!empty($callback)) $callback($file);
       }
     }
   }


### PR DESCRIPTION
- Expands the lookup of controllers based on the current query object
  `$wp_query` when processing template includes. Previously, WPS would
  only route for archive post type pages based on the value from
  `get_query_var('post_type')` which is not always valid depending on
  the current page/template being called
- Updates recursive file loader to allow for simily bypass of file
  inclusion, leaving callback method intact for contoller logic
