### PR TITLE
Fix bug where controller load path comes from page template

### DIFF
--- a/class.controller.php
+++ b/class.controller.php
@@ -53,14 +53,10 @@ class Controller {
   }
 
   public function index($template) {
-    $this->render_template($template);
+    include $template;
   }
 
   public function single($template) {
-    $this->render_template($template);
-  }
-
-  private function render_template($template) {
     include $template;
   }
 

--- a/class.controllers-loader.php
+++ b/class.controllers-loader.php
@@ -32,9 +32,9 @@ class ControllersLoader extends \WPS {
 
     $page_templates = is_array($current_page_templates) ?
       $current_page_templates :
-      [];
+      array_merge($page_templates, []);
 
-    $_wps_template_files = self::load_files_within(
+    self::load_files_within(
       WPS_VIEWS_DIR,
       'WPS\TemplatesRecursiveFilterIterator',
       'WPS\ControllersLoader::build_wp_page_templates_array',
@@ -60,13 +60,7 @@ class ControllersLoader extends \WPS {
   }
 
   public static function build_wp_page_templates_array($file) {
-    $local_file_path = str_replace(
-      get_template_directory(),
-      '',
-      $file->getPathname()
-    );
-
-    self::$_wp_page_templates[$local_file_path] = $file->getPathname();
+    self::$_wp_page_templates[$file->getFilename()] = $file->getPathname();
   }
 
   private static function get_current_post_type() {


### PR DESCRIPTION
- The page template path was unnecessary and only the filename is required
  however, currently custom page templates contain the full path so this
  commit amends this to only use the filename
- Removes `render_template` method from the base controller class as this
  prevents php variables from being created and passed to the template via
  the controller
- Also fixes issue found during this debug, whereby the currently stored
  page templates aren't included in the new filtered page template array
