### PR TITLE
Amend controller logic to factor in support for blog index

### DIFF
--- a/class.controller.php
+++ b/class.controller.php
@@ -12,14 +12,29 @@ class Controller {
     $this->render_post_route_template($template);
   }
 
+  public function index($template) {
+    include $template;
+  }
+
+  public function single($template) {
+    include $template;
+  }
+
   private function render_post_route_template($template) {
-    if(!is_post_type_archive()) {
+    if(!$this->is_index_of_post_type()) {
       $this->render_single_template($template);
 
       return;
     }
 
-  	$this->render_archive_template($template);
+  	$this->render_index_template($template);
+  }
+
+  private function is_index_of_post_type() {
+    $is_blog_index = is_home();
+    $this->index_template_prefix = $is_blog_index ? 'index' : 'archive';
+
+    return is_post_type_archive() || $is_blog_index;
   }
 
   private function render_single_template($template) {
@@ -39,9 +54,10 @@ class Controller {
     return;
   }
 
-  private function render_archive_template($template) {
+  private function render_index_template($template) {
     $archive_template = WPS_VIEWS_DIR .
-      "/{$this->post_type}/archive-{$this->post_type}.php";
+      "/{$this->post_type}/{$this->index_template_prefix}-{$this->post_type}" .
+      '.php';
 
     if(file_exists($archive_template)) {
       $this->index($archive_template);
@@ -49,15 +65,7 @@ class Controller {
       return;
     }
 
-    $this->single($template);
-  }
-
-  public function index($template) {
-    include $template;
-  }
-
-  public function single($template) {
-    include $template;
+    $this->index($template);
   }
 
   private function set_current_query($query) {

--- a/class.controllers-loader.php
+++ b/class.controllers-loader.php
@@ -64,6 +64,8 @@ class ControllersLoader extends \WPS {
   }
 
   private static function get_current_post_type() {
+    if(self::is_blog_index()) return self::set_blog_index_post_type();
+
     $post_type = !empty(self::$current_query->query['post_type']) ?
       self::$current_query->query['post_type'] :
       self::$current_query->queried_object->post_type;
@@ -111,6 +113,21 @@ class ControllersLoader extends \WPS {
       '',
       implode('-', array_map('ucfirst', explode('-', $post_type)))
     ) . 'Controller';
+  }
+
+  private static function is_blog_index() {
+    return is_home();
+  }
+
+  private static function set_blog_index_post_type() {
+    $post_type = 'post';
+    $blog_index_template = WPS_VIEWS_DIR . "/$post_type/index-$post_type.php";
+
+    if(file_exists($blog_index_template)) {
+      self::$template = $blog_index_template;
+    }
+
+    return $post_type;
   }
 }
 


### PR DESCRIPTION
* Currently, WPS doesn't recognise the post index when visiting the
page for posts.

* This commit fixes this issue by amending the `WPS\ControllerLoader`
class to check if the current page being requested is the blog listing
page and also sets the template to look for `index-post.php` file within
the `post` post type views folder.

* Also amends the `WPS\Controller` class to correctly filter index
templates, based on post type, either using the `archive-` or `index-`
prefixes for the template, i.e. `archive-portfolio.php` or
`index-post.php`