### PR TITLE
Update WPS autoloader with support for Concept classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $template_dir = get_template_directory();
 define('WPS_INCLUDES_DIR', $template_dir . '/includes/wps');
 
 // Sets the directories for each element of the WPS MVC pattern
+define('WPS_APP_DIR', $template_dir . '/app');
 define('WPS_MODELS_DIR', $template_dir . '/app/models');
 define('WPS_VIEWS_DIR', $template_dir . '/app/views');
 define('WPS_CONTROLLERS_DIR', $template_dir . '/app/controllers');
@@ -88,7 +89,7 @@ This file is then referenced in your functions file (see the functions file
 example code above), allow access to these defined constants across your WP
 theme.
 
-### Structure
+## Structure
 
 Whilst this repo contains just the core library of WPS and is separate from the
 theme structure, it is important to note that by using the MVC elements (models,
@@ -279,6 +280,45 @@ and because the template being requested is the `archive` template
 (`archive-portfolio.php`), the `index` method is called. The `$portfolio_items`
 variable is then exposed to the template and available within the view.
 
-Note: Currently only `archive-{$post_type}.php` files are supported and routed
-through these controllers. This will be updated in future PR's in order to fully
-support standard templates and individual posts/pages prior to `v1.0.0`
+For single post type templates, use the following format when naming files:
+`single-{$post_type}.php` in conjunction with the `single` controller method.
+
+For the blog index page, use the following format: `index-post.php` along with
+the `index` controller method within the `PostController` class.
+
+### Adding standalone classes/methods
+
+During your WordPress theme development, you'll likely come to a point at which
+you need to separate function (potentially shared) away from a controller or
+model and need to house this somewhere.
+
+WPS supports this 'wildcard' structuring by allowing for concept classes to be
+added to a subfolder within the `/app` directory.
+
+For example: You have a class which handles the navigation between post type
+items (i.e. the next post in the collection). This logic is doesn't belong in
+the controller or model, not only because it has separate concerns but also
+because it can be used across multiple post types. Therefore, we can add the
+class file (`NextPost` for this example) to a new folder within `/app/concepts`.
+
+The class must then be namespaced inline with the named parent folder, see the
+code example below:
+
+```php
+<?php
+
+namespace Concepts;
+
+class NextPost {
+  // Class methods go here
+}
+```
+
+To then call this class in your model or controller, you must reference the
+class via it's namespace: `$next_post = new Concepts\NextPost()`.
+
+Note: The subfolder can be named whatever is most appropriate for the containing
+class(es). If you have a set of classes which handle different external
+services, a folder named `services` would be better suited. You can add as many
+of these folders as required but keep in mind that this should not be used as a
+general 'dumping ground' for anonymous methods/functionality.

--- a/class.autoloaders.php
+++ b/class.autoloaders.php
@@ -17,6 +17,14 @@ class Autoloaders {
     $class_file_path = self::class_file_path($class_name);
 
     if(file_exists($class_file_path)) require_once $class_file_path;
+
+    $app_namespaced_class_file_path = self::app_namespaced_class_file_path(
+      $class_name
+    );
+
+    if(file_exists($app_namespaced_class_file_path)) {
+      require_once $app_namespaced_class_file_path;
+    }
   }
 
   public static function autoload_lib_classes($name) {
@@ -36,7 +44,8 @@ class Autoloaders {
 
   protected static function class_file_path($filename) {
     if(strpos($filename, '\\') !== false) {
-      return self::load_wps_namespaced_class($filename);
+      return trailingslashit(dirname(WPS_INCLUDES_DIR)) .
+        self::load_namespaced_class($filename);
     }
 
     $lowercase_filename = strtolower($filename);
@@ -47,18 +56,22 @@ class Autoloaders {
     return self::load_wps_app_files($lowercase_filename);
   }
 
-  private static function load_wps_namespaced_class($filename) {
+  protected static function app_namespaced_class_file_path($filename) {
+    return trailingslashit(WPS_APP_DIR) .
+      self::load_namespaced_class($filename);
+  }
+
+  private static function load_namespaced_class($filename) {
     $file_path_parts = explode('/', str_replace('\\', '/', $filename));
     $file_path_keys = array_keys($file_path_parts);
     $class_filename_key = end($file_path_keys);
     $class_filename = self::format_class_filename(
       $file_path_parts[$class_filename_key]
     );
-    $file_path_parts[$class_filename_key] = 'class.' . $class_filename  . '.php';
+    $file_path_parts[$class_filename_key] = 'class.' .
+      ltrim($class_filename, '-')  . '.php';
 
-    return trailingslashit(dirname(WPS_INCLUDES_DIR)) . strtolower(
-      implode($file_path_parts, '/')
-    );
+    return strtolower(implode($file_path_parts, '/'));
   }
 
   private static function load_wps_app_files($filename) {


### PR DESCRIPTION
* Allows for addition of namespaced concept classes to WPS-Core project,
with supporting autoloaders in place to handle the loading of these
custom classes regardless of naming convention (providing they are
within a folder within the `/app` directory)