### PR TITLE
Amend file template prefix array

### DIFF
--- a/class.controllers-loader.php
+++ b/class.controllers-loader.php
@@ -132,5 +132,5 @@ class ControllersLoader extends \WPS {
 }
 
 class TemplatesRecursiveFilterIterator extends FilterIterator {
-  protected $file_prefixes = ['page', 'single'];
+  protected $file_prefixes = ['page', 'archive', 'index'];
 }


### PR DESCRIPTION
* Removes `single` from lookup array (as single files should never
become templates for anything but themselves) and adds `archive` and
`index` so that these can be assigned to pages in order to allow for
CMB2 hooks to target specific parent listing pages by the template