### PR TITLE
Amend namespaced class autoloader

### DIFF
--- a/class.autoloaders.php
+++ b/class.autoloaders.php
@@ -19,7 +19,7 @@ class Autoloaders {
     if(file_exists($class_file_path)) require_once $class_file_path;
 
     $app_namespaced_class_file_path = self::app_namespaced_class_file_path(
-      $class_name
+      $name
     );
 
     if(file_exists($app_namespaced_class_file_path)) {


### PR DESCRIPTION
* Corrects file name passed to namespaced autoloader as was previously
being passed formatted class name which caused sub-namespaced classes
to be prefixed with hyphens, making them impossible to find during
lookup